### PR TITLE
Stop reboot test if PHY not detected

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -19,6 +19,12 @@ count=$(cat /data/fcount)
 count=$(expr ${count} + 1)
 echo ${count} > /data/fcount
 
+if dmesg | grep -q 'MDIO device at address 0 is missing'; then
+	echo "PHY not detected, idling forever..."
+	rm -f /data/fcount
+	tail -f /dev/null
+fi
+
 if [ "${count}" -gt 101 ]; then
 	echo "Completed reboot test"
 	rm -f /data/fcount


### PR DESCRIPTION
Stop the reboot test if PHY not detected so logs are not cycled.

Signed-off-by: Kyle Harding <kyle@balena.io>